### PR TITLE
Skip banned players when determining world record and player progression data

### DIFF
--- a/src/DevilDaggersInfo.sln
+++ b/src/DevilDaggersInfo.sln
@@ -127,6 +127,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DevilDaggersInfo.Web.Server
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DevilDaggersInfo.Web.Server.Domain.Main", "web-server\DevilDaggersInfo.Web.Server.Domain.Main\DevilDaggersInfo.Web.Server.Domain.Main.csproj", "{1E1CB75A-3F82-406A-8E07-D370B4405E64}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DevilDaggersInfo.Web.Server.Domain.Main.Tests", "tests\DevilDaggersInfo.Web.Server.Domain.Main.Tests\DevilDaggersInfo.Web.Server.Domain.Main.Tests.csproj", "{D2A8B6DE-F046-454C-95C9-1DD7889C5430}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DevilDaggersInfo.Web.Server.Domain.Tests", "tests\DevilDaggersInfo.Web.Server.Domain.Tests\DevilDaggersInfo.Web.Server.Domain.Tests.csproj", "{CB715CD9-FB6A-4E79-B9C0-830833223D91}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "api", "api", "{5C5B0BBB-04F2-467A-B708-C013543C0C31}"
@@ -447,6 +449,10 @@ Global
 		{2FFBA8A2-7A98-4E72-816E-273CCC22F030}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2FFBA8A2-7A98-4E72-816E-273CCC22F030}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2FFBA8A2-7A98-4E72-816E-273CCC22F030}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D2A8B6DE-F046-454C-95C9-1DD7889C5430}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2A8B6DE-F046-454C-95C9-1DD7889C5430}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D2A8B6DE-F046-454C-95C9-1DD7889C5430}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D2A8B6DE-F046-454C-95C9-1DD7889C5430}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -529,6 +535,7 @@ Global
 		{32271EED-3D11-4812-8D8C-307852D3A209} = {8B991433-4D58-4930-BE3A-4A33CD2BCB47}
 		{55BB7DBD-BFD0-4489-81C0-E909BBBEAF71} = {5C5B0BBB-04F2-467A-B708-C013543C0C31}
 		{2FFBA8A2-7A98-4E72-816E-273CCC22F030} = {8B991433-4D58-4930-BE3A-4A33CD2BCB47}
+		{D2A8B6DE-F046-454C-95C9-1DD7889C5430} = {139163CB-F521-45E4-B022-780DF7322293}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E27EC676-81BF-4099-BFC9-20E860CE83A5}

--- a/src/tests/DevilDaggersInfo.Web.Server.Domain.Main.Tests/DevilDaggersInfo.Web.Server.Domain.Main.Tests.csproj
+++ b/src/tests/DevilDaggersInfo.Web.Server.Domain.Main.Tests/DevilDaggersInfo.Web.Server.Domain.Main.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\..\.runsettings</RunSettingsFilePath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\web-server\DevilDaggersInfo.Web.Server.Domain.Main\DevilDaggersInfo.Web.Server.Domain.Main.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/tests/DevilDaggersInfo.Web.Server.Domain.Main.Tests/PlayerHistoryRepositoryTests.cs
+++ b/src/tests/DevilDaggersInfo.Web.Server.Domain.Main.Tests/PlayerHistoryRepositoryTests.cs
@@ -1,0 +1,190 @@
+using DevilDaggersInfo.Api.Main.Players;
+using DevilDaggersInfo.Types.Web;
+using DevilDaggersInfo.Web.Server.Domain.Entities;
+using DevilDaggersInfo.Web.Server.Domain.Main.Repositories;
+using DevilDaggersInfo.Web.Server.Domain.Models.FileSystem;
+using DevilDaggersInfo.Web.Server.Domain.Models.LeaderboardHistory;
+using DevilDaggersInfo.Web.Server.Domain.Services.Caching;
+using DevilDaggersInfo.Web.Server.Domain.Services.Inversion;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace DevilDaggersInfo.Web.Server.Domain.Main.Tests;
+
+[TestClass]
+public class PlayerHistoryRepositoryTests
+{
+	private readonly PlayerHistoryRepository _repository;
+
+	public PlayerHistoryRepositoryTests()
+	{
+		// Create an in-memory database
+		DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
+			.UseInMemoryDatabase(databaseName: "DevilDaggersInfo")
+			.Options;
+		TestDbContext dbContext = new(options, new Mock<IHttpContextAccessor>().Object, new Mock<ILogContainerService>().Object);
+		TestData data = new();
+		_repository = new(dbContext, data, data);
+	}
+
+	[TestMethod]
+	public void TestGetWorldRecordsData()
+	{
+		GetPlayerHistory historyPlayer1 = _repository.GetPlayerHistoryById(1);
+
+		// Verify that this player always has first place, even if a cheater has technically been first in the history at some point.
+		Assert.AreEqual(3, historyPlayer1.ScoreHistory.Count);
+		Assert.AreEqual(1, historyPlayer1.ScoreHistory[0].Rank);
+		Assert.AreEqual(1, historyPlayer1.ScoreHistory[1].Rank);
+		Assert.AreEqual(1, historyPlayer1.ScoreHistory[2].Rank);
+		Assert.AreEqual(new(2022, 1, 1), historyPlayer1.ScoreHistory[0].DateTime);
+		Assert.AreEqual(new(2022, 1, 3), historyPlayer1.ScoreHistory[1].DateTime);
+		Assert.AreEqual(new(2022, 1, 4), historyPlayer1.ScoreHistory[2].DateTime);
+
+		Assert.AreEqual(1, historyPlayer1.RankHistory.Count);
+		Assert.AreEqual(1, historyPlayer1.RankHistory[0].Rank);
+		Assert.AreEqual(new(2022, 1, 1), historyPlayer1.RankHistory[0].DateTime);
+
+		Assert.AreEqual(1, historyPlayer1.BestRank);
+
+		GetPlayerHistory historyPlayer2 = _repository.GetPlayerHistoryById(2);
+
+		// Verify that this player always has second place, even if a cheater has technically been first in the history at some point.
+		Assert.AreEqual(2, historyPlayer2.ScoreHistory.Count);
+		Assert.AreEqual(2, historyPlayer2.ScoreHistory[0].Rank);
+		Assert.AreEqual(2, historyPlayer2.ScoreHistory[1].Rank);
+		Assert.AreEqual(new(2022, 1, 1), historyPlayer2.ScoreHistory[0].DateTime);
+		Assert.AreEqual(new(2022, 1, 3), historyPlayer2.ScoreHistory[1].DateTime);
+
+		Assert.AreEqual(1, historyPlayer2.RankHistory.Count);
+		Assert.AreEqual(2, historyPlayer2.RankHistory[0].Rank);
+		Assert.AreEqual(new(2022, 1, 1), historyPlayer2.RankHistory[0].DateTime);
+
+		Assert.AreEqual(2, historyPlayer2.BestRank);
+
+		GetPlayerHistory historyPlayer3 = _repository.GetPlayerHistoryById(3);
+
+		// Verify that this player's best rank is 3rd, even if a cheater has always been above them.
+		Assert.AreEqual(1, historyPlayer3.ScoreHistory.Count);
+		Assert.AreEqual(3, historyPlayer3.ScoreHistory[0].Rank);
+		Assert.AreEqual(new(2022, 1, 4), historyPlayer3.RankHistory[0].DateTime);
+
+		Assert.AreEqual(1, historyPlayer3.RankHistory.Count);
+		Assert.AreEqual(3, historyPlayer3.RankHistory[0].Rank);
+		Assert.AreEqual(new(2022, 1, 4), historyPlayer3.RankHistory[0].DateTime);
+
+		Assert.AreEqual(3, historyPlayer3.BestRank);
+
+		GetPlayerHistory historyCheater = _repository.GetPlayerHistoryById(4);
+
+		// A cheater's history is not affected, except if there is another cheater with a better rank (which we don't test here because we don't care about accurate cheater stats).
+		Assert.AreEqual(3, historyCheater.ScoreHistory.Count);
+		Assert.AreEqual(1, historyCheater.ScoreHistory[0].Rank);
+		Assert.AreEqual(3, historyCheater.ScoreHistory[1].Rank);
+		Assert.AreEqual(1, historyCheater.ScoreHistory[2].Rank);
+		Assert.AreEqual(new(2022, 1, 2), historyCheater.ScoreHistory[0].DateTime);
+		Assert.AreEqual(new(2022, 1, 3), historyCheater.ScoreHistory[1].DateTime);
+		Assert.AreEqual(new(2022, 1, 4), historyCheater.ScoreHistory[2].DateTime);
+
+		Assert.AreEqual(3, historyCheater.RankHistory.Count);
+		Assert.AreEqual(1, historyCheater.RankHistory[0].Rank);
+		Assert.AreEqual(3, historyCheater.RankHistory[1].Rank);
+		Assert.AreEqual(1, historyCheater.RankHistory[2].Rank);
+		Assert.AreEqual(new(2022, 1, 2), historyCheater.RankHistory[0].DateTime);
+		Assert.AreEqual(new(2022, 1, 3), historyCheater.RankHistory[1].DateTime);
+		Assert.AreEqual(new(2022, 1, 4), historyCheater.RankHistory[2].DateTime);
+
+		Assert.AreEqual(1, historyCheater.BestRank);
+	}
+
+	private sealed class TestDbContext : ApplicationDbContext
+	{
+		public TestDbContext(DbContextOptions<TestDbContext> options, IHttpContextAccessor httpContextAccessor, ILogContainerService logContainerService)
+			: base(options, httpContextAccessor, logContainerService)
+		{
+			List<PlayerEntity> players = new()
+			{
+				new() { Id = 1, BanType = BanType.NotBanned, PlayerName = "Player 1" },
+				new() { Id = 2, BanType = BanType.NotBanned, PlayerName = "Player 2" },
+				new() { Id = 3, BanType = BanType.NotBanned, PlayerName = "Player 3" },
+				new() { Id = 4, BanType = BanType.Cheater, PlayerName = "Cheater" },
+			};
+
+			Players.AddRange(players);
+			SaveChanges();
+		}
+
+		public override DbSet<PlayerEntity> Players => Set<PlayerEntity>();
+	}
+
+	private sealed class TestData : ILeaderboardHistoryCache, IFileSystemService
+	{
+		private readonly IReadOnlyDictionary<string, LeaderboardHistory> _data = new Dictionary<string, LeaderboardHistory>
+		{
+			["2022-01-01.bin"] = new()
+			{
+				DateTime = new(2022, 1, 1),
+				Entries = new()
+				{
+					new() { Rank = 1, Id = 1, Time = 90 },
+					new() { Rank = 2, Id = 2, Time = 80 },
+				},
+			},
+			["2022-01-02.bin"] = new()
+			{
+				DateTime = new(2022, 1, 2),
+				Entries = new()
+				{
+					new() { Rank = 1, Id = 4, Time = 100000 }, // Cheater makes it to first place.
+					new() { Rank = 2, Id = 1, Time = 90 },
+					new() { Rank = 3, Id = 2, Time = 80 },
+				},
+			},
+			["2022-01-03.bin"] = new()
+			{
+				DateTime = new(2022, 1, 3),
+				Entries = new()
+				{
+					new() { Rank = 1, Id = 1, Time = 95 },
+					new() {	Rank = 2, Id = 2, Time = 85 },
+					new() { Rank = 3, Id = 4, Time = 0 }, // Cheater is removed from the leaderboard.
+				},
+			},
+			["2022-01-04.bin"] = new()
+			{
+				DateTime = new(2022, 1, 4),
+				Entries = new()
+				{
+					new() { Rank = 1, Id = 4, Time = 1000000 }, // Cheater makes it to first place again.
+					new() { Rank = 2, Id = 1, Time = 98 },
+					new() { Rank = 3, Id = 2, Time = 85 },
+					new() { Rank = 4, Id = 3, Time = 82 }, // Player 3 joins the leaderboard.
+				},
+			},
+		};
+
+		public string[] TryGetFiles(DataSubDirectory subDirectory)
+		{
+			if (subDirectory != DataSubDirectory.LeaderboardHistory)
+				throw new NotImplementedException();
+
+			return _data.Keys.ToArray();
+		}
+
+		public LeaderboardHistory GetLeaderboardHistoryByFilePath(string filePath)
+		{
+			return _data[filePath];
+		}
+
+ #pragma warning disable SA1201
+		public string Root => throw new NotImplementedException();
+		public string GetLeaderboardHistoryPathFromDate(DateTime dateTime) => throw new NotImplementedException();
+		public string GetPath(DataSubDirectory subDirectory) => throw new NotImplementedException();
+		public string GetToolDistributionPath(string name, ToolPublishMethod publishMethod, ToolBuildType buildType, string version) => throw new NotImplementedException();
+		public int GetCount() => throw new NotImplementedException();
+		public void Clear() => throw new NotImplementedException();
+ #pragma warning restore SA1201
+	}
+}

--- a/src/tests/DevilDaggersInfo.Web.Server.Domain.Main.Tests/PlayerHistoryRepositoryTests.cs
+++ b/src/tests/DevilDaggersInfo.Web.Server.Domain.Main.Tests/PlayerHistoryRepositoryTests.cs
@@ -17,7 +17,7 @@ public class PlayerHistoryRepositoryTests
 	public PlayerHistoryRepositoryTests()
 	{
 		DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
-			.UseInMemoryDatabase(databaseName: "DevilDaggersInfo")
+			.UseInMemoryDatabase(databaseName: nameof(PlayerHistoryRepositoryTests))
 			.Options;
 		TestDbContext dbContext = new(options, new Mock<IHttpContextAccessor>().Object, new Mock<ILogContainerService>().Object);
 		TestData data = new();

--- a/src/tests/DevilDaggersInfo.Web.Server.Domain.Main.Tests/PlayerHistoryRepositoryTests.cs
+++ b/src/tests/DevilDaggersInfo.Web.Server.Domain.Main.Tests/PlayerHistoryRepositoryTests.cs
@@ -1,10 +1,6 @@
 using DevilDaggersInfo.Api.Main.Players;
-using DevilDaggersInfo.Types.Web;
-using DevilDaggersInfo.Web.Server.Domain.Entities;
 using DevilDaggersInfo.Web.Server.Domain.Main.Repositories;
-using DevilDaggersInfo.Web.Server.Domain.Models.FileSystem;
-using DevilDaggersInfo.Web.Server.Domain.Models.LeaderboardHistory;
-using DevilDaggersInfo.Web.Server.Domain.Services.Caching;
+using DevilDaggersInfo.Web.Server.Domain.Main.Tests.Utils;
 using DevilDaggersInfo.Web.Server.Domain.Services.Inversion;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -20,7 +16,6 @@ public class PlayerHistoryRepositoryTests
 
 	public PlayerHistoryRepositoryTests()
 	{
-		// Create an in-memory database
 		DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
 			.UseInMemoryDatabase(databaseName: "DevilDaggersInfo")
 			.Options;
@@ -30,7 +25,7 @@ public class PlayerHistoryRepositoryTests
 	}
 
 	[TestMethod]
-	public void TestGetWorldRecordsData()
+	public void GetPlayerHistory_WithCheater()
 	{
 		GetPlayerHistory historyPlayer1 = _repository.GetPlayerHistoryById(1);
 
@@ -97,94 +92,5 @@ public class PlayerHistoryRepositoryTests
 		Assert.AreEqual(new(2022, 1, 4), historyCheater.RankHistory[2].DateTime);
 
 		Assert.AreEqual(1, historyCheater.BestRank);
-	}
-
-	private sealed class TestDbContext : ApplicationDbContext
-	{
-		public TestDbContext(DbContextOptions<TestDbContext> options, IHttpContextAccessor httpContextAccessor, ILogContainerService logContainerService)
-			: base(options, httpContextAccessor, logContainerService)
-		{
-			List<PlayerEntity> players = new()
-			{
-				new() { Id = 1, BanType = BanType.NotBanned, PlayerName = "Player 1" },
-				new() { Id = 2, BanType = BanType.NotBanned, PlayerName = "Player 2" },
-				new() { Id = 3, BanType = BanType.NotBanned, PlayerName = "Player 3" },
-				new() { Id = 4, BanType = BanType.Cheater, PlayerName = "Cheater" },
-			};
-
-			Players.AddRange(players);
-			SaveChanges();
-		}
-
-		public override DbSet<PlayerEntity> Players => Set<PlayerEntity>();
-	}
-
-	private sealed class TestData : ILeaderboardHistoryCache, IFileSystemService
-	{
-		private readonly IReadOnlyDictionary<string, LeaderboardHistory> _data = new Dictionary<string, LeaderboardHistory>
-		{
-			["2022-01-01.bin"] = new()
-			{
-				DateTime = new(2022, 1, 1),
-				Entries = new()
-				{
-					new() { Rank = 1, Id = 1, Time = 90 },
-					new() { Rank = 2, Id = 2, Time = 80 },
-				},
-			},
-			["2022-01-02.bin"] = new()
-			{
-				DateTime = new(2022, 1, 2),
-				Entries = new()
-				{
-					new() { Rank = 1, Id = 4, Time = 100000 }, // Cheater makes it to first place.
-					new() { Rank = 2, Id = 1, Time = 90 },
-					new() { Rank = 3, Id = 2, Time = 80 },
-				},
-			},
-			["2022-01-03.bin"] = new()
-			{
-				DateTime = new(2022, 1, 3),
-				Entries = new()
-				{
-					new() { Rank = 1, Id = 1, Time = 95 },
-					new() {	Rank = 2, Id = 2, Time = 85 },
-					new() { Rank = 3, Id = 4, Time = 0 }, // Cheater is removed from the leaderboard.
-				},
-			},
-			["2022-01-04.bin"] = new()
-			{
-				DateTime = new(2022, 1, 4),
-				Entries = new()
-				{
-					new() { Rank = 1, Id = 4, Time = 1000000 }, // Cheater makes it to first place again.
-					new() { Rank = 2, Id = 1, Time = 98 },
-					new() { Rank = 3, Id = 2, Time = 85 },
-					new() { Rank = 4, Id = 3, Time = 82 }, // Player 3 joins the leaderboard.
-				},
-			},
-		};
-
-		public string[] TryGetFiles(DataSubDirectory subDirectory)
-		{
-			if (subDirectory != DataSubDirectory.LeaderboardHistory)
-				throw new NotImplementedException();
-
-			return _data.Keys.ToArray();
-		}
-
-		public LeaderboardHistory GetLeaderboardHistoryByFilePath(string filePath)
-		{
-			return _data[filePath];
-		}
-
- #pragma warning disable SA1201
-		public string Root => throw new NotImplementedException();
-		public string GetLeaderboardHistoryPathFromDate(DateTime dateTime) => throw new NotImplementedException();
-		public string GetPath(DataSubDirectory subDirectory) => throw new NotImplementedException();
-		public string GetToolDistributionPath(string name, ToolPublishMethod publishMethod, ToolBuildType buildType, string version) => throw new NotImplementedException();
-		public int GetCount() => throw new NotImplementedException();
-		public void Clear() => throw new NotImplementedException();
- #pragma warning restore SA1201
 	}
 }

--- a/src/tests/DevilDaggersInfo.Web.Server.Domain.Main.Tests/Utils/TestData.cs
+++ b/src/tests/DevilDaggersInfo.Web.Server.Domain.Main.Tests/Utils/TestData.cs
@@ -1,0 +1,76 @@
+using DevilDaggersInfo.Types.Web;
+using DevilDaggersInfo.Web.Server.Domain.Models.FileSystem;
+using DevilDaggersInfo.Web.Server.Domain.Models.LeaderboardHistory;
+using DevilDaggersInfo.Web.Server.Domain.Services.Caching;
+using DevilDaggersInfo.Web.Server.Domain.Services.Inversion;
+
+namespace DevilDaggersInfo.Web.Server.Domain.Main.Tests.Utils;
+
+public class TestData : ILeaderboardHistoryCache, IFileSystemService
+{
+	private readonly IReadOnlyDictionary<string, LeaderboardHistory> _data = new Dictionary<string, LeaderboardHistory>
+	{
+		["2022-01-01.bin"] = new()
+		{
+			DateTime = new(2022, 1, 1),
+			Entries = new()
+			{
+				new() { Rank = 1, Id = 1, Time = 90 },
+				new() { Rank = 2, Id = 2, Time = 80 },
+			},
+		},
+		["2022-01-02.bin"] = new()
+		{
+			DateTime = new(2022, 1, 2),
+			Entries = new()
+			{
+				new() { Rank = 1, Id = 4, Time = 100000 }, // Cheater makes it to first place.
+				new() { Rank = 2, Id = 1, Time = 90 },
+				new() { Rank = 3, Id = 2, Time = 80 },
+			},
+		},
+		["2022-01-03.bin"] = new()
+		{
+			DateTime = new(2022, 1, 3),
+			Entries = new()
+			{
+				new() { Rank = 1, Id = 1, Time = 95 },
+				new() {	Rank = 2, Id = 2, Time = 85 },
+				new() { Rank = 3, Id = 4, Time = 0 }, // Cheater is removed from the leaderboard.
+			},
+		},
+		["2022-01-04.bin"] = new()
+		{
+			DateTime = new(2022, 1, 4),
+			Entries = new()
+			{
+				new() { Rank = 1, Id = 4, Time = 1000000 }, // Cheater makes it to first place again.
+				new() { Rank = 2, Id = 1, Time = 98 },
+				new() { Rank = 3, Id = 2, Time = 85 },
+				new() { Rank = 4, Id = 3, Time = 82 }, // Player 3 joins the leaderboard.
+			},
+		},
+	};
+
+	public string[] TryGetFiles(DataSubDirectory subDirectory)
+	{
+		if (subDirectory != DataSubDirectory.LeaderboardHistory)
+			throw new NotImplementedException();
+
+		return _data.Keys.ToArray();
+	}
+
+	public LeaderboardHistory GetLeaderboardHistoryByFilePath(string filePath)
+	{
+		return _data[filePath];
+	}
+
+#pragma warning disable SA1201
+	public string Root => throw new NotImplementedException();
+	public string GetLeaderboardHistoryPathFromDate(DateTime dateTime) => throw new NotImplementedException();
+	public string GetPath(DataSubDirectory subDirectory) => throw new NotImplementedException();
+	public string GetToolDistributionPath(string name, ToolPublishMethod publishMethod, ToolBuildType buildType, string version) => throw new NotImplementedException();
+	public int GetCount() => throw new NotImplementedException();
+	public void Clear() => throw new NotImplementedException();
+#pragma warning restore SA1201
+}

--- a/src/tests/DevilDaggersInfo.Web.Server.Domain.Main.Tests/Utils/TestDbContext.cs
+++ b/src/tests/DevilDaggersInfo.Web.Server.Domain.Main.Tests/Utils/TestDbContext.cs
@@ -1,0 +1,27 @@
+using DevilDaggersInfo.Types.Web;
+using DevilDaggersInfo.Web.Server.Domain.Entities;
+using DevilDaggersInfo.Web.Server.Domain.Services.Inversion;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace DevilDaggersInfo.Web.Server.Domain.Main.Tests.Utils;
+
+public class TestDbContext : ApplicationDbContext
+{
+	public TestDbContext(DbContextOptions<TestDbContext> options, IHttpContextAccessor httpContextAccessor, ILogContainerService logContainerService)
+		: base(options, httpContextAccessor, logContainerService)
+	{
+		List<PlayerEntity> players = new()
+		{
+			new() { Id = 1, BanType = BanType.NotBanned, PlayerName = "Player 1" },
+			new() { Id = 2, BanType = BanType.NotBanned, PlayerName = "Player 2" },
+			new() { Id = 3, BanType = BanType.NotBanned, PlayerName = "Player 3" },
+			new() { Id = 4, BanType = BanType.Cheater, PlayerName = "Cheater" },
+		};
+
+		Players.AddRange(players);
+		SaveChanges();
+	}
+
+	public override DbSet<PlayerEntity> Players => Set<PlayerEntity>();
+}

--- a/src/tests/DevilDaggersInfo.Web.Server.Domain.Main.Tests/WorldRecordRepositoryTests.cs
+++ b/src/tests/DevilDaggersInfo.Web.Server.Domain.Main.Tests/WorldRecordRepositoryTests.cs
@@ -17,7 +17,7 @@ public class WorldRecordRepositoryTests
 	public WorldRecordRepositoryTests()
 	{
 		DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
-			.UseInMemoryDatabase(databaseName: "DevilDaggersInfo")
+			.UseInMemoryDatabase(databaseName: nameof(WorldRecordRepositoryTests))
 			.Options;
 		TestDbContext dbContext = new(options, new Mock<IHttpContextAccessor>().Object, new Mock<ILogContainerService>().Object);
 		TestData data = new();

--- a/src/tests/DevilDaggersInfo.Web.Server.Domain.Main.Tests/WorldRecordRepositoryTests.cs
+++ b/src/tests/DevilDaggersInfo.Web.Server.Domain.Main.Tests/WorldRecordRepositoryTests.cs
@@ -1,0 +1,45 @@
+using DevilDaggersInfo.Api.Main.WorldRecords;
+using DevilDaggersInfo.Web.Server.Domain.Main.Repositories;
+using DevilDaggersInfo.Web.Server.Domain.Main.Tests.Utils;
+using DevilDaggersInfo.Web.Server.Domain.Services.Inversion;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace DevilDaggersInfo.Web.Server.Domain.Main.Tests;
+
+[TestClass]
+public class WorldRecordRepositoryTests
+{
+	private readonly WorldRecordRepository _repository;
+
+	public WorldRecordRepositoryTests()
+	{
+		DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
+			.UseInMemoryDatabase(databaseName: "DevilDaggersInfo")
+			.Options;
+		TestDbContext dbContext = new(options, new Mock<IHttpContextAccessor>().Object, new Mock<ILogContainerService>().Object);
+		TestData data = new();
+		_repository = new(dbContext, data, data);
+	}
+
+	[TestMethod]
+	public void GetWorldRecords_WithCheater()
+	{
+		GetWorldRecordDataContainer worldRecordData = _repository.GetWorldRecordData();
+
+		Assert.AreEqual(1, worldRecordData.WorldRecordHolders.Count);
+		Assert.AreEqual(1, worldRecordData.WorldRecordHolders[0].Id);
+		Assert.AreEqual(3, worldRecordData.WorldRecordHolders[0].WorldRecordCount);
+
+		const double delta = 0.00001;
+		Assert.AreEqual(3, worldRecordData.WorldRecords.Count);
+		Assert.AreEqual(1, worldRecordData.WorldRecords[0].Entry.Id);
+		Assert.AreEqual(0.0090, worldRecordData.WorldRecords[0].Entry.Time, delta);
+		Assert.AreEqual(1, worldRecordData.WorldRecords[1].Entry.Id);
+		Assert.AreEqual(0.0095, worldRecordData.WorldRecords[1].Entry.Time, delta);
+		Assert.AreEqual(1, worldRecordData.WorldRecords[2].Entry.Id);
+		Assert.AreEqual(0.0098, worldRecordData.WorldRecords[2].Entry.Time, delta);
+	}
+}

--- a/src/web-client/DevilDaggersInfo.Web.Client/DevilDaggersInfo.Web.Client.csproj
+++ b/src/web-client/DevilDaggersInfo.Web.Client/DevilDaggersInfo.Web.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <DateTimeUtcNow>$([System.DateTime]::UtcNow.ToString("yyyy-MM-dd-HH-mm"))</DateTimeUtcNow>
-    <Version>5.7.0.0-$(DateTimeUtcNow)</Version>
+    <Version>5.7.1.0-$(DateTimeUtcNow)</Version>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <IntermediateOutputPath>obj</IntermediateOutputPath>
     <RunAnalyzers>false</RunAnalyzers>

--- a/src/web-client/DevilDaggersInfo.Web.Client/wwwroot/news/V5.8 Update.html
+++ b/src/web-client/DevilDaggersInfo.Web.Client/wwwroot/news/V5.8 Update.html
@@ -1,0 +1,13 @@
+<h3 class="text-red text-xl pt-4 pb-2 font-goethe">Enhancements</h3>
+
+<p class="para">
+	Banned players (meaning bans tracked by DevilDaggers.info, not "official" bans) are now skipped when determining world records, world record holders, and player progression (rank and score).
+</p>
+
+<p class="para">
+	This means that if your world record is beaten by a banned player, you will not lose your world record. Or if your best rank is 101 on the leaderboard, but the player at rank 100 is banned, your best rank will be set to 100.
+</p>
+
+<p class="para">
+	This is effective immediately for all history whenever a player is banned or unbanned.
+</p>

--- a/src/web-server/DevilDaggersInfo.Web.Server.Domain.Main/Repositories/LeaderboardHistoryStatisticsRepository.cs
+++ b/src/web-server/DevilDaggersInfo.Web.Server.Domain.Main/Repositories/LeaderboardHistoryStatisticsRepository.cs
@@ -10,9 +10,9 @@ namespace DevilDaggersInfo.Web.Server.Domain.Main.Repositories;
 public class LeaderboardHistoryStatisticsRepository
 {
 	private readonly IFileSystemService _fileSystemService;
-	private readonly LeaderboardHistoryCache _leaderboardHistoryCache;
+	private readonly ILeaderboardHistoryCache _leaderboardHistoryCache;
 
-	public LeaderboardHistoryStatisticsRepository(IFileSystemService fileSystemService, LeaderboardHistoryCache leaderboardHistoryCache)
+	public LeaderboardHistoryStatisticsRepository(IFileSystemService fileSystemService, ILeaderboardHistoryCache leaderboardHistoryCache)
 	{
 		_fileSystemService = fileSystemService;
 		_leaderboardHistoryCache = leaderboardHistoryCache;

--- a/src/web-server/DevilDaggersInfo.Web.Server.Domain.Main/Repositories/PlayerHistoryRepository.cs
+++ b/src/web-server/DevilDaggersInfo.Web.Server.Domain.Main/Repositories/PlayerHistoryRepository.cs
@@ -13,9 +13,9 @@ public class PlayerHistoryRepository
 {
 	private readonly ApplicationDbContext _dbContext;
 	private readonly IFileSystemService _fileSystemService;
-	private readonly LeaderboardHistoryCache _leaderboardHistoryCache;
+	private readonly ILeaderboardHistoryCache _leaderboardHistoryCache;
 
-	public PlayerHistoryRepository(ApplicationDbContext dbContext, IFileSystemService fileSystemService, LeaderboardHistoryCache leaderboardHistoryCache)
+	public PlayerHistoryRepository(ApplicationDbContext dbContext, IFileSystemService fileSystemService, ILeaderboardHistoryCache leaderboardHistoryCache)
 	{
 		_dbContext = dbContext;
 		_fileSystemService = fileSystemService;

--- a/src/web-server/DevilDaggersInfo.Web.Server.Domain.Main/Repositories/WorldRecordRepository.cs
+++ b/src/web-server/DevilDaggersInfo.Web.Server.Domain.Main/Repositories/WorldRecordRepository.cs
@@ -8,7 +8,6 @@ using DevilDaggersInfo.Web.Server.Domain.Models.FileSystem;
 using DevilDaggersInfo.Web.Server.Domain.Models.LeaderboardHistory;
 using DevilDaggersInfo.Web.Server.Domain.Services.Caching;
 using DevilDaggersInfo.Web.Server.Domain.Services.Inversion;
-using Microsoft.EntityFrameworkCore;
 
 namespace DevilDaggersInfo.Web.Server.Domain.Main.Repositories;
 
@@ -127,6 +126,7 @@ public class WorldRecordRepository
 
 	private List<BaseWorldRecord> GetBaseWorldRecords()
 	{
+		// WRs made on an alt can be legit, we'll just swap it with the main account.
 		List<int> bannedPlayerIds = _dbContext.Players.Select(p => new { p.Id, p.BanType }).Where(p => p.BanType != BanType.Alt && p.BanType != BanType.NotBanned).Select(p => p.Id).ToList();
 
 		DateTime? previousDate = null;

--- a/src/web-server/DevilDaggersInfo.Web.Server.Domain.Main/Repositories/WorldRecordRepository.cs
+++ b/src/web-server/DevilDaggersInfo.Web.Server.Domain.Main/Repositories/WorldRecordRepository.cs
@@ -2,6 +2,7 @@ using DevilDaggersInfo.Api.Main.WorldRecords;
 using DevilDaggersInfo.Common.Extensions;
 using DevilDaggersInfo.Core.Wiki;
 using DevilDaggersInfo.Types.Core.Wiki;
+using DevilDaggersInfo.Types.Web;
 using DevilDaggersInfo.Web.Server.Domain.Entities;
 using DevilDaggersInfo.Web.Server.Domain.Models.FileSystem;
 using DevilDaggersInfo.Web.Server.Domain.Models.LeaderboardHistory;
@@ -126,21 +127,39 @@ public class WorldRecordRepository
 
 	private List<BaseWorldRecord> GetBaseWorldRecords()
 	{
+		List<int> bannedPlayerIds = _dbContext.Players.Select(p => new { p.Id, p.BanType }).Where(p => p.BanType != BanType.Alt && p.BanType != BanType.NotBanned).Select(p => p.Id).ToList();
+
 		DateTime? previousDate = null;
 		List<BaseWorldRecord> worldRecords = new();
 		int worldRecord = 0;
 
 		List<LeaderboardHistory> history = _fileSystemService.TryGetFiles(DataSubDirectory.LeaderboardHistory).Where(p => p.EndsWith(".bin")).Select(f => _leaderboardHistoryCache.GetLeaderboardHistoryByFilePath(f)).OrderBy(lbh => lbh.DateTime).ToList();
-		for (int i = 0; i < history.Count; i++)
+		foreach (LeaderboardHistory leaderboard in history)
 		{
-			LeaderboardHistory leaderboard = history[i];
-			EntryHistory? firstPlace = leaderboard.Entries.Find(e => e.Rank == 1);
-			if (firstPlace == null)
+			// Find the WR, if the actual first place is not legit, get second place, etc.
+			EntryHistory? firstLegitPlace = null;
+
+			// ReSharper disable once LoopCanBeConvertedToQuery
+			for (int i = 0; i < leaderboard.Entries.Count; i++)
+			{
+				int rank = i + 1;
+				EntryHistory? entry = leaderboard.Entries.Find(e => e.Rank == rank);
+				if (entry == null)
+					break; // Entry with current rank is not present on this leaderboard, meaning we cannot determine what the WR was.
+
+				if (bannedPlayerIds.Contains(entry.Id))
+					continue; // The actual WR is not legit, find the next entry.
+
+				firstLegitPlace = entry;
+				break;
+			}
+
+			if (firstLegitPlace == null)
 				continue;
 
-			if (firstPlace.Time != worldRecord)
+			if (firstLegitPlace.Time != worldRecord)
 			{
-				worldRecord = firstPlace.Time;
+				worldRecord = firstLegitPlace.Time;
 
 				DateTime date;
 
@@ -153,19 +172,19 @@ public class WorldRecordRepository
 					date = leaderboard.DateTime;
 
 				// If the WR was submitted by an alt, we need to manually fix the ID by looking up the main ID in the database.
-				int? mainPlayerId = _dbContext.Players.AsNoTracking().Select(p => new { p.Id, p.BanResponsibleId }).FirstOrDefault(p => p.Id == firstPlace.Id)?.BanResponsibleId;
+				int? mainPlayerId = _dbContext.Players.Select(p => new { p.Id, p.BanResponsibleId }).FirstOrDefault(p => p.Id == firstLegitPlace.Id)?.BanResponsibleId;
 
 				GetWorldRecordEntry getWorldRecordEntry = new()
 				{
 					DateTime = leaderboard.DateTime,
-					Id = mainPlayerId ?? firstPlace.Id,
-					Username = firstPlace.Username,
-					Time = firstPlace.Time.ToSecondsTime(),
-					Kills = firstPlace.Kills,
-					Gems = firstPlace.Gems,
-					DeathType = firstPlace.DeathType,
-					DaggersHit = firstPlace.DaggersHit,
-					DaggersFired = firstPlace.DaggersFired,
+					Id = mainPlayerId ?? firstLegitPlace.Id,
+					Username = firstLegitPlace.Username,
+					Time = firstLegitPlace.Time.ToSecondsTime(),
+					Kills = firstLegitPlace.Kills,
+					Gems = firstLegitPlace.Gems,
+					DeathType = firstLegitPlace.DeathType,
+					DaggersHit = firstLegitPlace.DaggersHit,
+					DaggersFired = firstLegitPlace.DaggersFired,
 				};
 				worldRecords.Add(new(date, getWorldRecordEntry, GameVersions.GetGameVersionFromDate(date)));
 			}

--- a/src/web-server/DevilDaggersInfo.Web.Server.Domain.Main/Repositories/WorldRecordRepository.cs
+++ b/src/web-server/DevilDaggersInfo.Web.Server.Domain.Main/Repositories/WorldRecordRepository.cs
@@ -18,9 +18,9 @@ public class WorldRecordRepository
 
 	private readonly ApplicationDbContext _dbContext;
 	private readonly IFileSystemService _fileSystemService;
-	private readonly LeaderboardHistoryCache _leaderboardHistoryCache;
+	private readonly ILeaderboardHistoryCache _leaderboardHistoryCache;
 
-	public WorldRecordRepository(ApplicationDbContext dbContext, IFileSystemService fileSystemService, LeaderboardHistoryCache leaderboardHistoryCache)
+	public WorldRecordRepository(ApplicationDbContext dbContext, IFileSystemService fileSystemService, ILeaderboardHistoryCache leaderboardHistoryCache)
 	{
 		_dbContext = dbContext;
 		_fileSystemService = fileSystemService;

--- a/src/web-server/DevilDaggersInfo.Web.Server.Domain/Services/Caching/ILeaderboardHistoryCache.cs
+++ b/src/web-server/DevilDaggersInfo.Web.Server.Domain/Services/Caching/ILeaderboardHistoryCache.cs
@@ -1,0 +1,12 @@
+using DevilDaggersInfo.Web.Server.Domain.Models.LeaderboardHistory;
+
+namespace DevilDaggersInfo.Web.Server.Domain.Services.Caching;
+
+public interface ILeaderboardHistoryCache
+{
+	LeaderboardHistory GetLeaderboardHistoryByFilePath(string filePath);
+
+	int GetCount();
+
+	void Clear();
+}

--- a/src/web-server/DevilDaggersInfo.Web.Server.Domain/Services/Caching/LeaderboardHistoryCache.cs
+++ b/src/web-server/DevilDaggersInfo.Web.Server.Domain/Services/Caching/LeaderboardHistoryCache.cs
@@ -3,15 +3,15 @@ using System.Collections.Concurrent;
 
 namespace DevilDaggersInfo.Web.Server.Domain.Services.Caching;
 
-public class LeaderboardHistoryCache
+public class LeaderboardHistoryCache : ILeaderboardHistoryCache
 {
 	private readonly ConcurrentDictionary<string, LeaderboardHistory> _cache = new();
 
 	public LeaderboardHistory GetLeaderboardHistoryByFilePath(string filePath)
 	{
 		string name = Path.GetFileNameWithoutExtension(filePath);
-		if (_cache.ContainsKey(name))
-			return _cache[name];
+		if (_cache.TryGetValue(name, out LeaderboardHistory? value))
+			return value;
 
 		LeaderboardHistory lb = LeaderboardHistory.CreateFromFile(File.ReadAllBytes(filePath));
 		_cache.TryAdd(name, lb);

--- a/src/web-server/DevilDaggersInfo.Web.Server/Controllers/Admin/CachesController.cs
+++ b/src/web-server/DevilDaggersInfo.Web.Server/Controllers/Admin/CachesController.cs
@@ -11,7 +11,7 @@ namespace DevilDaggersInfo.Web.Server.Controllers.Admin;
 public class CachesController : ControllerBase
 {
 	private readonly LeaderboardStatisticsCache _leaderboardStatisticsCache;
-	private readonly LeaderboardHistoryCache _leaderboardHistoryCache;
+	private readonly ILeaderboardHistoryCache _leaderboardHistoryCache;
 	private readonly ModArchiveCache _modArchiveCache;
 	private readonly SpawnsetSummaryCache _spawnsetSummaryCache;
 	private readonly SpawnsetHashCache _spawnsetHashCache;
@@ -19,7 +19,7 @@ public class CachesController : ControllerBase
 
 	public CachesController(
 		LeaderboardStatisticsCache leaderboardStatisticsCache,
-		LeaderboardHistoryCache leaderboardHistoryCache,
+		ILeaderboardHistoryCache leaderboardHistoryCache,
 		ModArchiveCache modArchiveCache,
 		SpawnsetSummaryCache spawnsetSummaryCache,
 		SpawnsetHashCache spawnsetHashCache,

--- a/src/web-server/DevilDaggersInfo.Web.Server/Controllers/Main/LeaderboardHistoryController.cs
+++ b/src/web-server/DevilDaggersInfo.Web.Server/Controllers/Main/LeaderboardHistoryController.cs
@@ -11,9 +11,9 @@ namespace DevilDaggersInfo.Web.Server.Controllers.Main;
 public class LeaderboardHistoryController : ControllerBase
 {
 	private readonly IFileSystemService _fileSystemService;
-	private readonly LeaderboardHistoryCache _leaderboardHistoryCache;
+	private readonly ILeaderboardHistoryCache _leaderboardHistoryCache;
 
-	public LeaderboardHistoryController(IFileSystemService fileSystemService, LeaderboardHistoryCache leaderboardHistoryCache)
+	public LeaderboardHistoryController(IFileSystemService fileSystemService, ILeaderboardHistoryCache leaderboardHistoryCache)
 	{
 		_fileSystemService = fileSystemService;
 		_leaderboardHistoryCache = leaderboardHistoryCache;

--- a/src/web-server/DevilDaggersInfo.Web.Server/HostedServices/StartupCacheHostedService.cs
+++ b/src/web-server/DevilDaggersInfo.Web.Server/HostedServices/StartupCacheHostedService.cs
@@ -11,7 +11,7 @@ public class StartupCacheHostedService : IHostedService
 	private readonly IFileSystemService _fileSystemService;
 	private readonly ILogContainerService _logContainerService;
 	private readonly LeaderboardStatisticsCache _leaderboardStatisticsCache;
-	private readonly LeaderboardHistoryCache _leaderboardHistoryCache;
+	private readonly ILeaderboardHistoryCache _leaderboardHistoryCache;
 	private readonly ModArchiveCache _modArchiveCache;
 
 	public StartupCacheHostedService(
@@ -19,7 +19,7 @@ public class StartupCacheHostedService : IHostedService
 		IFileSystemService fileSystemService,
 		ILogContainerService logContainerService,
 		LeaderboardStatisticsCache leaderboardStatisticsCache,
-		LeaderboardHistoryCache leaderboardHistoryCache,
+		ILeaderboardHistoryCache leaderboardHistoryCache,
 		ModArchiveCache modArchiveCache)
 	{
 		_env = env;

--- a/src/web-server/DevilDaggersInfo.Web.Server/Startup.cs
+++ b/src/web-server/DevilDaggersInfo.Web.Server/Startup.cs
@@ -99,7 +99,7 @@ public class Startup
 		services.AddSingleton<ResponseTimeMonitor>();
 
 		// Caching services
-		services.AddSingleton<LeaderboardHistoryCache>();
+		services.AddSingleton<ILeaderboardHistoryCache, LeaderboardHistoryCache>();
 		services.AddSingleton<LeaderboardStatisticsCache>();
 		services.AddSingleton<ModArchiveCache>();
 		services.AddSingleton<SpawnsetSummaryCache>();


### PR DESCRIPTION
TODO:

- [x] Skip banned players when determining world record data
- [x] Skip banned players when determining player progression data
- [x] Unit tests for `WorldRecordRepository`
- [x] Unit tests for `PlayerHistoryRepository`
- [x] Add changelog for v5.8