### PR TITLE
Specify global SDK version

### DIFF
--- a/src/global.json
+++ b/src/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "7.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
This is just to make sure we can have .NET 8 installed without using it for these projects yet.